### PR TITLE
Added dnslib as a requirement in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+dnslib
 argparse
 dnspython
 requests


### PR DESCRIPTION
Addressing the error caused by missing dnslib:

$pip install -r requirements.txt
$python turbolist3r.py -d example.com
Traceback (most recent call last):
  File "turbolist3r.py", line 35, in <module>
    import dnslib
ImportError: No module named dnslib
